### PR TITLE
[DO NOT MERGE][WIP][IGNORE][ARCHIVE ONLY] Temporary test fixes, still unstable, Hotfix/remove secure token fillable

### DIFF
--- a/app/Http/Controllers/Api/TaskController.php
+++ b/app/Http/Controllers/Api/TaskController.php
@@ -94,9 +94,10 @@ class TaskController extends Controller
 
         $task = $this->taskModel->create([
             'name' => $request->name,
-            'description' => $request->description,
-            'secure_token' => (string) Str::uuid(),
+            'description' => $request->description
         ]);
+        $task->secure_token = (string) Str::uuid();
+        $task->save();
 
         return response()->json(['message' => 'Task created', 'task' => $task], 201);
     }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -12,8 +12,6 @@ class Task extends Eloquent
     
     protected $connection = 'mongodb';
     protected $collection = 'project_tasks';
-    protected $fillable = ['name', 'description', 'secure_token'];
+    protected $fillable = ['name', 'description'];
     protected $dates = ['deleted_at'];
-    protected $guarded = [];
-    protected string|null $secure_token;
 }

--- a/tests/Unit/Controllers/TaskControllerUnitTest.php
+++ b/tests/Unit/Controllers/TaskControllerUnitTest.php
@@ -70,32 +70,28 @@ class TaskControllerUnitTest extends TestCase
         $expectedName = 'New Task';
         $expectedDescription = 'This is a new task description';
         $expectedToken = 'token123';
+        $expectedToken = (string) Str::uuid();
 
-        // Prepare mock request data
-        $requestData = [
-            'name' => $expectedName,
-            'description' => $expectedDescription,
-        ];
+        $createdTask = Mockery::mock(Task::class)->makePartial();
+        $createdTask->name = $expectedName;
+        $createdTask->description = $expectedDescription;
+        $createdTask->secure_token = $expectedToken;
+        $createdTask->shouldReceive('save')->once();
 
-        // Prepare a fake Task object to be returned from create()
-        $createdTask = (object) array_merge($requestData, [
-            'secure_token' => $expectedToken,
-        ]);
-
-        // Mock the Task model
         $taskMock = Mockery::mock(Task::class);
         $taskMock->shouldReceive('create')
-                ->once()
-                ->with(Mockery::on(function ($arg) use ($requestData) {
-                    return $arg['name'] === $requestData['name']
-                            && $arg['description'] === $requestData['description']
-                            && isset($arg['secure_token']);
-                }))
-                ->andReturn($createdTask);
+            ->once()
+            ->with(Mockery::on(function ($arg) use ($expectedName, $expectedDescription) {
+                return $arg['name'] === $expectedName
+                    && $arg['description'] === $expectedDescription;
+            }))
+            ->andReturn($createdTask);
 
-        // Create a mock request with input data
         $request = new \Illuminate\Http\Request();
-        $request->replace($requestData);
+        $request->replace([
+            'name' => $expectedName,
+            'description' => $expectedDescription,
+        ]);
 
         // Instantiate controller with mock model
         $controller = new TaskController($taskMock);


### PR DESCRIPTION
**[DO NOT MERGE][WIP][IGNORE][ARCHIVE ONLY]** 

 Temporary commit for test reference, not final

This PR contains temporary changes for unit test debugging.
Please do not merge yet. It's for future reference only.

**Changes**
- Hotfix/remove 'secure_token' from fillable and guarded attributes
    - Reason: This improves mass assignment protection and aligns the model with Laravel's Eloquent best practices. The `secure_token` is now handled internally and does not need to be mass-assignable.
    - Removed `'secure_token'` from the `$fillable` array in the `Task` model
    - Removed the unnecessary `$guarded = [];` line
    - Deleted the `protected string|null $secure_token;` property declaration
- **WIP**: Partial refactor of TaskController unit test; issues remain, saving progress for reference

**Note:**  
This branch will be discarded and not merged.  

**Reason:**  
We will **not remove** `'secure_token'` from the `$fillable` array, reverting it back to the original state.  
Keeping `'secure_token'` out of the `$fillable` array does not pose a risk because the token is generated internally during `create` operations, and this approach simplifies the code. Therefore, we decided to abandon this branch and continue with the original design.


